### PR TITLE
change tooltip text to reflect correct mod time

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,12 +64,12 @@
             </label>
           </div>
           <div class="checkbox">
-            <label data-toggle="tooltip" data-trigger="hover" data-placement="right" title="per stamina spent: 4.5 minutes without VIP or 6 minutes with VIP">
+            <label data-toggle="tooltip" data-trigger="hover" data-placement="right" title="per stamina spent: 9 minutes without VIP or 12 minutes with VIP">
               <input type="checkbox" data-option="bahamut-lagoon" data-option-group="boost"> Bahamut Lagoon
             </label>
           </div>
           <div class="checkbox">
-            <label data-toggle="tooltip" data-trigger="hover" data-placement="right" title="per stamina spent outside Bahamut Lagoon: 4 minutes with VIP instead of 3">
+            <label data-toggle="tooltip" data-trigger="hover" data-placement="right" title="per stamina spent outside Bahamut Lagoon: 8 minutes with VIP instead of 6">
               <input type="checkbox" data-option="vip-mode" data-option-group="boost"> VIP Mode
             </label>
           </div>


### PR DESCRIPTION
forgot to change the tooltip from last PR on changing the boost time for 3rd anniversary update (JP: 4th anniversary update)